### PR TITLE
add deploy argument to pipenv install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ LABEL version=1.0 maintainer="Stax Development Team" author="Mark Wolfe"
 RUN pip install pipenv
 ADD Pipfile Pipfile.lock /src/
 WORKDIR /src
-RUN pipenv install --system
+RUN pipenv install --deploy --system
 
 ENTRYPOINT ["/usr/local/bin/cfn-lint"]


### PR DESCRIPTION
Add --deploy to pipenv install command to ensure lock file is up to date.

https://pipenv.pypa.io/en/latest/advanced/#using-pipenv-for-deployments