### PR TITLE
chore(dependabot): update package ecosystem to correct value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  - package-ecosystem: pipenv
+  - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
As per https://docs.github.com/en/enterprise-server@3.6/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem pipenv == pip for the `package-ecosystem` value.