### PR TITLE
feat(platform): add serverless rules module for enhanced checks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,3 +6,4 @@ name = "pypi"
 [packages]
 cfn-lint = "*"
 shell = "*"
+cfn-lint-serverless = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "090892b4a00cc395702f81a170a346ab281254f0243a852b0f276fd322d460d3"
+            "sha256": "ab891b67bad4d7794c6c01845fbc6347932d3b81d2dec1ac74e575835d49ecb5"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -55,6 +55,15 @@
             "markers": "python_version >= '3.7' and python_version != '4.0' and python_version <= '4.0'",
             "version": "==0.79.9"
         },
+        "cfn-lint-serverless": {
+            "hashes": [
+                "sha256:6ad3b753008b02e472740f807bd2295dbe7db4b4c9f8a9023507534ff2122da9",
+                "sha256:c9d8f93b3d96611b301875cdb7ebe0a75c407edf65d50ea5d8f984838f2b6b42"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
+            "version": "==0.3.2"
+        },
         "jmespath": {
             "hashes": [
                 "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
@@ -102,14 +111,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==4.17.3"
-        },
-        "jsonschema-specifications": {
-            "hashes": [
-                "sha256:05adf340b659828a004220a9613be00fa3f223f2b82002e273dee62fd50524b1",
-                "sha256:c91a50404e88a1f6ba40636778e2ee08f6e24c5613fe4c53ac24578a5a7f72bb"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2023.7.1"
         },
         "junit-xml": {
             "hashes": [
@@ -280,14 +281,6 @@
             "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
-        "referencing": {
-            "hashes": [
-                "sha256:449b6669b6121a9e96a7f9e410b245d471e8d48964c67113ce9afe50c8dd7bdf",
-                "sha256:794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.30.2"
-        },
         "regex": {
             "hashes": [
                 "sha256:0085da0f6c6393428bf0d9c08d8b1874d805bb55e17cb1dfa5ddb7cfb11140bf",
@@ -381,109 +374,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2023.8.8"
-        },
-        "rpds-py": {
-            "hashes": [
-                "sha256:00e97d43a36811b78fa9ad9d3329bf34f76a31e891a7031a2ac01450c9b168ab",
-                "sha256:013d6c784150d10236a74b4094a79d96a256b814457e388fc5a4ba9efe24c402",
-                "sha256:0188b580c490bccb031e9b67e9e8c695a3c44ac5e06218b152361eca847317c3",
-                "sha256:02945ae38fd78efc40900f509890de84cfd5ffe2cd2939eeb3a8800dc68b87cb",
-                "sha256:02b4a2e28eb24dac4ef43dda4f6a6f7766e355179b143f7d0c76a1c5488a307b",
-                "sha256:0527c97dcd8bb983822ee31d3760187083fd3ba18ac4dd22cf5347c89d5628f4",
-                "sha256:05a1382905026bdd560f806c8c7c16e0f3e3fb359ba8868203ca6e5799884968",
-                "sha256:0b309908b6ff5ffbf6394818cb73b5a2a74073acee2c57fe8719046389aeff0d",
-                "sha256:0fc625059b83695fbb4fc8b7a8b66fa94ff9c7b78c84fb9986cd53ff88a28d80",
-                "sha256:177c033e467a66a054dd3a9534167234a3d0b2e41445807b13b626e01da25d92",
-                "sha256:18909093944727e068ebfc92e2e6ed1c4fa44135507c1c0555213ce211c53214",
-                "sha256:1adb04e4b4e41bf30aaa77eeb169c1b9ba9e5010e2e6ce8d6c17e1446edc9b68",
-                "sha256:1ed3d5385d14be894e12a9033be989e012214a9811e7194849c94032ad69682a",
-                "sha256:203eb1532d51591d32e8dfafd60b5d31347ea7278c8da02b4b550287f6abe28b",
-                "sha256:213f9ef5c02ec2f883c1075d25a873149daadbaea50d18d622e9db55ec9849c2",
-                "sha256:2275f1a022e2383da5d2d101fe11ccdcbae799148c4b83260a4b9309fa3e1fc2",
-                "sha256:22e6de18f00583f06928cc8d0993104ecc62f7c6da6478db2255de89a30e45d1",
-                "sha256:289073f68452b96e70990085324be7223944c7409973d13ddfe0eea1c1b5663b",
-                "sha256:29ec8507664f94cc08457d98cfc41c3cdbddfa8952438e644177a29b04937876",
-                "sha256:2a55631b93e47956fbc97d69ba2054a8c6a4016f9a3064ec4e031f5f1030cb90",
-                "sha256:2a86d246a160d98d820ee7d02dc18c923c228de095be362e57b9fd8970b2c4a1",
-                "sha256:2bca97521ee786087f0c5ef318fef3eef0266a9c3deff88205523cf353af7394",
-                "sha256:2c8fc6c841ada60a86d29c9ebe2e8757c47eda6553f3596c560e59ca6e9b6fa1",
-                "sha256:2cd0c9fb5d40887500b4ed818770c68ab4fa6e0395d286f9704be6751b1b7d98",
-                "sha256:2d27d08056fcd61ff47a0cd8407eff4d3e816c82cb6b9c6f0ce9a0ad49225f81",
-                "sha256:2ffbf1b38c88d0466de542e91b08225d51782282512f8e2b11715126c41fda48",
-                "sha256:3fd503c27e7b7034128e30847ecdb4bff4ca5e60f29ad022a9f66ae8940d54ac",
-                "sha256:3ff1f585a0fdc1415bd733b804f33d386064a308672249b14828130dd43e7c31",
-                "sha256:41bd430b7b63aa802c02964e331ac0b177148fef5f807d2c90d05ce71a52b4d4",
-                "sha256:43e9b1531d6a898bdf086acb75c41265c7ec4331267d7619148d407efc72bd24",
-                "sha256:46af4a742b90c7460e94214f923452c2c1d050a9da1d2b8d4c70cbc045e692b7",
-                "sha256:46c4c550bf59ce05d6bff2c98053822549aaf9fbaf81103edea325e03350bca1",
-                "sha256:4969592e3cdeefa4cbb15a26cec102cbd4a1d6e5b695fac9fa026e19741138c8",
-                "sha256:4a0536ed2b9297c75104e1a3da330828ba1b2639fa53b38d396f98bf7e3c68df",
-                "sha256:4a96147791e49e84207dd1530109aa0e9eeaf1c8b7a59f150047fc0fcdf9bb64",
-                "sha256:4c7f9d70f99e1fbcbf57c75328b80e1c0a7f6cad43e75efa90a97221be5efe15",
-                "sha256:4e8474f7233fe1949ce4e03bea698a600c2d5d6b51dab6d6e6336dbe69acf23e",
-                "sha256:4f1b804cfad04f862d6a84af9d1ad941b06f671878f0f7ecad6c92007d423de6",
-                "sha256:529aab727f54a937085184e7436e1d0e19975cf10115eda12d37a683e4ee5342",
-                "sha256:5612b0b1de8d5114520094bd5fc3d04eb8af6f3e10d48ef05b7c8e77c1fd9545",
-                "sha256:56777c57246e048908b550af9b81b0ec9cf804fd47cb7502ccd93238bd6025c2",
-                "sha256:56ba7c1100ed079527f2b995bf5486a2e557e6d5b733c52e8947476338815b69",
-                "sha256:59d222086daa55421d599609b32d0ebe544e57654c4a0a1490c54a7ebaa67561",
-                "sha256:5aba767e64b494483ad60c4873bec78d16205a21f8247c99749bd990d9c846c2",
-                "sha256:5d5eaf988951f6ecb6854ca3300b87123599c711183c83da7ce39717a7cbdbce",
-                "sha256:73da69e1f612c3e682e34dcb971272d90d6f27b2c99acff444ca455a89978574",
-                "sha256:75c8766734ac0053e1d683567e65e85306c4ec62631b0591caeb287ac8f72e08",
-                "sha256:75eea40355a8690459c7291ce6c8ce39c27bd223675c7da6619f510c728feb97",
-                "sha256:80c3cf46511653f94dfe07c7c79ab105c4164d6e1dfcb35b7214fb9af53eaef4",
-                "sha256:8557c807388e6617161fe51b1a4747ea8d1133f2d2ad8e79583439abebe58fbd",
-                "sha256:89438e8885a186c69fe31f7ef98bb2bf29688c466c3caf9060f404c0be89ae80",
-                "sha256:899b03a3be785a7e1ff84b237da71f0efa2f021512f147dd34ffdf7aa82cb678",
-                "sha256:8de9b88f0cbac73cfed34220d13c57849e62a7099a714b929142425e926d223a",
-                "sha256:8f4d561f4728f825e3b793a53064b606ca0b6fc264f67d09e54af452aafc5b82",
-                "sha256:907b214da5d2fcff0b6ddb83de1333890ca92abaf4bbf8d9c61dc1b95c87fd6e",
-                "sha256:9118de88c16947eaf5b92f749e65b0501ea69e7c2be7bd6aefc12551622360e1",
-                "sha256:9568764e72d85cf7855ca78b48e07ed1be47bf230e2cea8dabda3c95f660b0ff",
-                "sha256:9c74cbee9e532dc34371127f7686d6953e5153a1f22beab7f953d95ee4a0fe09",
-                "sha256:9cdfd649011ce2d90cb0dd304c5aba1190fac0c266d19a9e2b96b81cfd150a09",
-                "sha256:9f00d54b18dd837f1431d66b076737deb7c29ce3ebb8412ceaf44d5e1954ac0c",
-                "sha256:a2f416cdfe92f5fbb77177f5f3f7830059d1582db05f2c7119bf80069d1ab69b",
-                "sha256:a4cb372e22e9c879bd9a9cc9b20b7c1fbf30a605ac953da45ecec05d8a6e1c77",
-                "sha256:a65de5c02884760a14a58304fb6303f9ddfc582e630f385daea871e1bdb18686",
-                "sha256:aa3b3a43dabc4cc57a7800f526cbe03f71c69121e21b863fdf497b59b462b163",
-                "sha256:ab0f7aabdbce4a202e013083eeab71afdb85efa405dc4a06fea98cde81204675",
-                "sha256:abe081453166e206e3a8c6d8ace57214c17b6d9477d7601ac14a365344dbc1f4",
-                "sha256:ae141c9017f8f473a6ee07a9425da021816a9f8c0683c2e5442f0ccf56b0fc62",
-                "sha256:af52078719209bef33e38131486fd784832dd8d1dc9b85f00a44f6e7437dd021",
-                "sha256:b00150a9a3fd0a8efaa90bc2696c105b04039d50763dd1c95a34c88c5966cb57",
-                "sha256:b2660000e1a113869c86eb5cc07f3343467490f3cd9d0299f81da9ddae7137b7",
-                "sha256:b3eb1a0d2b6d232d1bcdfc3fcc5f7b004ab3fbd9203011a3172f051d4527c0b6",
-                "sha256:b589d93a60e78fe55d5bc76ee8c2bf945dbdbb7cd16044c53e0307604e448de1",
-                "sha256:b8578fc6c8bdd0201327503720fa581000b4bd3934abbf07e2628d1ad3de157d",
-                "sha256:ba1b28e44f611f3f2b436bd8290050a61db4b59a8e24be4465f44897936b3824",
-                "sha256:bb44644371eaa29a3aba7b69b1862d0d56f073bb7585baa32e4271a71a91ee82",
-                "sha256:bcde80aefe7054fad6277762fb7e9d35c72ea479a485ae1bb14629c640987b30",
-                "sha256:bd1142d22fdb183a0fff66d79134bf644401437fed874f81066d314c67ee193c",
-                "sha256:bf77f9017fcfa1232f98598a637406e6c33982ccba8a5922339575c3e2b90ea5",
-                "sha256:c2772bb95062e3f9774140205cd65d8997e39620715486cf5f843cf4ad8f744c",
-                "sha256:c4ecc4e9a5d73a816cae36ee6b5d8b7a0c72013cae1e101406e832887c3dc2d8",
-                "sha256:c86231c66e4f422e7c13ea6200bb4048b3016c8bfd11b4fd0dabd04d2c8e3501",
-                "sha256:c8f6526df47953b07c45b95c4d1da6b9a0861c0e5da0271db96bb1d807825412",
-                "sha256:ccfb77f6dc8abffa6f1c7e3975ed9070a41ce5fcc11154d2bead8c1baa940f09",
-                "sha256:d9d7efaad48b859053b90dedd69bc92f2095084251e732e4c57ac9726bcb1e64",
-                "sha256:dd91a7d7a9ce7f4983097c91ce211f3e5569cc21caa16f2692298a07e396f82b",
-                "sha256:de4a2fd524993578fe093044f291b4b24aab134390030b3b9b5f87fd41ab7e75",
-                "sha256:df61f818edf7c8626bfa392f825860fb670b5f8336e238eb0ec7e2a5689cdded",
-                "sha256:e1147bc3d0dd1e549d991110d0a09557ec9f925dbc1ca62871fcdab2ec9d716b",
-                "sha256:e1954f4b239d1a92081647eecfd51cbfd08ea16eb743b8af1cd0113258feea14",
-                "sha256:e281b71922208e00886e4b7ffbfcf27874486364f177418ab676f102130e7ec9",
-                "sha256:e69737bd56006a86fd5a78b2b85447580a6138c930a75eb9ef39fe03d90782b1",
-                "sha256:e82b4a70cc67094f3f3fd77579702f48fcf1de7bdc67d79b8f1e24d089a6162c",
-                "sha256:e92e5817eb6bfed23aa5e45bfe30647b83602bdd6f9e25d63524d4e6258458b0",
-                "sha256:eaba0613c759ebf95988a84f766ca6b7432d55ce399194f95dde588ad1be0878",
-                "sha256:edd74b760a6bb950397e7a7bd2f38e6700f6525062650b1d77c6d851b82f02c2",
-                "sha256:f40abbcc0a7d9a8a80870af839d317e6932533f98682aabd977add6c53beeb23",
-                "sha256:fce7a8ee8d0f682c953c0188735d823f0fcb62779bf92cd6ba473a8e730e26ad"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.10.2"
         },
         "s3transfer": {
             "hashes": [


### PR DESCRIPTION
This change enables extra rules https://github.com/awslabs/serverless-rules to validate more advanced checks on resources.

This can optionally be enabled with the following command.

```
docker run -it -v $(pwd):/src -w /src ghcr.io/stax-labs/cfn-lint-docker-image:latest template.yaml \
    -a cfn_lint_serverless.rules
```

Adding this to the container makes it feel even more batteries included as it adds more rules which could be classed as best practices. 

This includes ensuring every lambda has a log group specified, with a retention, among other checks.